### PR TITLE
feat: Add multiple lines to notes

### DIFF
--- a/pdf.go
+++ b/pdf.go
@@ -5,6 +5,7 @@ import (
 	"image"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/signintech/gopdf"
 )
@@ -98,11 +99,18 @@ func writeNotes(pdf *gopdf.GoPdf, notes string) {
 	pdf.SetTextColor(55, 55, 55)
 	_ = pdf.Cell(nil, "Notes")
 	pdf.Br(18)
+	_ = pdf.SetFont("Inter", "", 8)
 	pdf.SetTextColor(0, 0, 0)
-	_ = pdf.Cell(nil, notes)
+
+	notesLines := strings.Split(notes, "\\n")
+
+	for i := 0; i < len(notesLines); i++ {
+		_ = pdf.Cell(nil, notesLines[i])
+		pdf.Br(15)
+	}
+
 	pdf.Br(48)
 }
-
 func writeFooter(pdf *gopdf.GoPdf, id string) {
 	pdf.SetY(800)
 


### PR DESCRIPTION
Hey @maaslalani I don't know if this is good or you care to add it to the project but I created PR this for multiline support. I'm trying to get the json to read multiple objects too. I don't really write go so let me know if there is a some different approach in case you want this in. Otherwise have a good one

# Changes
* Notes fontSize reduced to allow more lines in the provided space (Currently I don't think more than 8 lines would manageble)
* Notes are split into lines based on `\n` (I read you were also thinking of using `<br>` so that could be an alternative)
