### PR TITLE
fix: Missing trailing comma in currencies

### DIFF
--- a/currency.go
+++ b/currency.go
@@ -10,5 +10,5 @@ var currencySymbols = map[string]string{
 	"RUB": "₽",
 	"KRW": "₩",
 	"BRL": "R$",
-	"SGD": "SGD$"
+	"SGD": "SGD$",
 }


### PR DESCRIPTION
I figured this was the part missing that essentially broke the `go install` for me.

LMK if it looks good!