### PR TITLE
Payment info on the invoice, added sale date, billing period, new currencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 *.yml
 *.sh
 !.github/workflows/*.yml
+
+# exclude generated binary from repo
+invoice
+
+# other
+.DS_Store

--- a/currency.go
+++ b/currency.go
@@ -3,6 +3,7 @@ package main
 var currencySymbols = map[string]string{
 	"USD": "$",
 	"EUR": "€",
+	"PLN": "zł",
 	"GBP": "£",
 	"JPY": "¥",
 	"CNY": "¥",
@@ -11,4 +12,5 @@ var currencySymbols = map[string]string{
 	"KRW": "₩",
 	"BRL": "R$",
 	"SGD": "SGD$",
+	"ZAR": "R",
 }

--- a/pdf.go
+++ b/pdf.go
@@ -53,7 +53,7 @@ func writeLogo(pdf *gopdf.GoPdf, logo string, from string) {
 	pdf.Br(36)
 }
 
-func writeTitle(pdf *gopdf.GoPdf, title, id, date string) {
+func writeTitle(pdf *gopdf.GoPdf, title, id, date, due, billingPeriod, saleDate string) {
 	_ = pdf.SetFont("Inter-Bold", "", 24)
 	pdf.SetTextColor(0, 0, 0)
 	_ = pdf.Cell(nil, title)
@@ -66,7 +66,35 @@ func writeTitle(pdf *gopdf.GoPdf, title, id, date string) {
 	_ = pdf.Cell(nil, "  ·  ")
 	pdf.SetTextColor(100, 100, 100)
 	_ = pdf.Cell(nil, date)
-	pdf.Br(48)
+
+	// Optional due date + billing period (rendered on the same line as issue date).
+	if due != "" {
+		pdf.SetTextColor(150, 150, 150)
+		_ = pdf.Cell(nil, "  ·  ")
+		pdf.SetTextColor(100, 100, 100)
+		_ = pdf.Cell(nil, "Due: ")
+		_ = pdf.Cell(nil, due)
+	}
+	if billingPeriod != "" {
+		pdf.SetTextColor(150, 150, 150)
+		_ = pdf.Cell(nil, "  ·  ")
+		pdf.SetTextColor(100, 100, 100)
+		_ = pdf.Cell(nil, "Billing period: ")
+		_ = pdf.Cell(nil, billingPeriod)
+	}
+
+	// Optional sale date (printed below issue date line).
+	if saleDate != "" {
+		pdf.Br(18)
+		_ = pdf.SetFont("Inter", "", 10)
+		pdf.SetTextColor(100, 100, 100)
+		_ = pdf.Cell(nil, "Sale date: ")
+		pdf.SetTextColor(0, 0, 0)
+		_ = pdf.Cell(nil, saleDate)
+		pdf.Br(33)
+	} else {
+		pdf.Br(48)
+	}
 }
 
 func writeDueDate(pdf *gopdf.GoPdf, due string) {
@@ -118,7 +146,7 @@ func writeHeaderRow(pdf *gopdf.GoPdf) {
 	pdf.Br(24)
 }
 
-func writeNotes(pdf *gopdf.GoPdf, notes string) {
+func writeNotes(pdf *gopdf.GoPdf, notes, paymentMethod, bank, swift, accountNo string) {
 	pdf.SetY(600)
 
 	_ = pdf.SetFont("Inter", "", 9)
@@ -127,6 +155,26 @@ func writeNotes(pdf *gopdf.GoPdf, notes string) {
 	pdf.Br(18)
 	_ = pdf.SetFont("Inter", "", 9)
 	pdf.SetTextColor(0, 0, 0)
+
+	if paymentMethod != "" {
+		_ = pdf.Cell(nil, "Payment: "+paymentMethod)
+		pdf.Br(15)
+	}
+	if bank != "" {
+		_ = pdf.Cell(nil, "Bank: "+bank)
+		pdf.Br(15)
+	}
+	if swift != "" {
+		_ = pdf.Cell(nil, "SWIFT: "+swift)
+		pdf.Br(15)
+	}
+	if accountNo != "" {
+		_ = pdf.Cell(nil, "Account no: "+accountNo)
+		pdf.Br(15)
+	}
+	if (paymentMethod != "" || bank != "" || swift != "" || accountNo != "") && notes != "" {
+		pdf.Br(15)
+	}
 
 	formattedNotes := strings.ReplaceAll(notes, `\n`, "\n")
 	notesLines := strings.Split(formattedNotes, "\n")


### PR DESCRIPTION
I needed more info on the invoice and also fixed a couple of issues from here.

These additional details have been added:

- paymentMethod - e.g. "bank transfer"
- bank - "name of bank"
- swift - "bank SWIFT no"
- accountNo - "account no"
- saleDate - these can sometimes be different than issue date, useful to have it
- billingPeriod - useful to indicate the exact billing period the invoice is for (this solves issue [#19](https://github.com/maaslalani/invoice/issues/19))

Added two new currencies. This also solves issue [#54](https://github.com/maaslalani/invoice/issues/54).

Added the binary and ds_store to gitignore.

Now the invoice looks like this:

<img width="761" height="1094" alt="inv example" src="https://github.com/user-attachments/assets/0f9956c2-9d16-459b-aa28-a442b3fa5deb" />